### PR TITLE
Rearrangement into logical categories

### DIFF
--- a/doc/PROFICIENCY_LIST.md
+++ b/doc/PROFICIENCY_LIST.md
@@ -1,7 +1,11 @@
 | id | name | description | required_proficiencies | can_learn
-| --- | --- | --- | --- | --- 
+| --- | --- | --- | --- | ---
+| prof_scav_cooking | Scavenger Cooking | You know the secrets of cooking tasty food using strange substitutions and weird things you found in a cabinet in an abandoned house. | None | True
+| prof_forage_cooking | Forager Cooking | Cooking with foraged ingredients that you wouldn't find in most cookbooks. | None | True
+| --- | --- | --- | --- | ---
 | prof_food_prep | Food Preparation | You've done enough cooking to know the basics about how to quickly and efficiently sort your ingredients. | None | True
 | prof_knife_skills | Knife Skills | You're quite skilled at culinary knife work, making you noticeably faster at preparing meals that involve a lot of chopping. | prof_food_prep | True
+| --- | --- | --- | --- | --- 
 | prof_baking | Principles of Baking | You know the basics of baking - proportions, leavening, and things - and are less likely to make a dramatic mistake when working from memory. | None | True
 | prof_baking_bread | Breadmaking | You've baked enough bread to consider yourself an expert.  May your yeast be ever frothy. | prof_baking | True
 | prof_baking_desserts_1 | Dessert Baking | Anyone can make a cookie, but you can make it look amazing.  Cakes and other fluffies are also no longer a barrier. | prof_baking | True
@@ -9,61 +13,22 @@
 | prof_frying | Principles of Frying | Anyone can toss stuff into deep frier oil.  You know more about selecting oil, keeping the food from burning, and the like. | None | True
 | prof_frying_bread | Breading & Battering | You know enough about deep frying breads and batters to do it easily without thinking about it. | prof_frying | True
 | prof_frying_dessert | Fried Desserts | You know the vaunted secrets of creating delicious deep fried sweets. | prof_frying / prof_baking_desserts_1 | True
-| prof_fermenting | Culinary Fermentation | The basics of fermenting for human consumption, including sanitary technique, avoiding harmful molds, and identifying common problems. | None | True
-| prof_beverage_distilling | Beverage Distillation | Applying the science of distillation to alcoholic beverages to get something tasty. | prof_distilling | True
-| prof_brewing | Brewing | The fine art of brewing grains into beers. | prof_fermenting | True
-| prof_winemaking | Winemaking | The knowledge of how to turn sugary fruits, and occasionally vegetables, into fermented beverages. | prof_fermenting | True
-| prof_lactofermenting | Lactofermentation | The microbiology of most non-alcoholic fermented edibles, from sauerkraut to sourdough. | prof_fermenting | True
-| prof_cheesemaking_1 | Principles of Cheesemaking | The basics of curdling and coagulating milk and similar things without the wrong kinds of bacteria and mold winning out. | None | True
-| prof_cheesemaking_2 | Cheesemaking Expert | Taking the basics of curdled milk and making it delicious. | prof_cheesemaking_1 | True
+| --- | --- | --- | --- | ---
 | prof_preservation | Food Preservation | The basic knowledge of ways to keep food safe for long periods of time in a post-refrigeration world. | None | True
 | prof_food_curing | Curing and Drying Food | Using salt, smoke, and similar agents to cure or dehydrate food. | prof_preservation | True
 | prof_food_canning | Canning Food | Using pressure canning or tinning to safely store food in sealed containers. | prof_preservation | True
-| prof_scav_cooking | Scavenger Cooking | You know the secrets of cooking tasty food using strange substitutions and weird things you found in a cabinet in an abandoned house. | None | True
-| prof_forage_cooking | Forager Cooking | Cooking with foraged ingredients that you wouldn't find in most cookbooks. | None | True
-| prof_lockpicking | Lockpicking | You know how to pick a lock, at least in theory. | None | True
-| prof_lockpicking_expert | Locksmith | You can pick a lock in the dark, blindfolded.  Although that doesn't make it all that much harder.  You're good at locks, OK? | prof_lockpicking | True
-| prof_safecracking | Safecracking | Opening safes is an exacting skill, one that you are proficient at. | None | True
-| prof_traps | Principles of Trapping | You know the basics of setting and taking down traps safely. | None | True
-| prof_trapsetting | Trap Setting | You're specifically quite skilled at setting effective traps. | prof_traps | True
-| prof_disarming | Trap Disarming | You know how to take down a trap safely. | prof_traps | True
-| prof_spotting | Spotting and Awareness | You are skilled at spotting things out of the ordinary, like traps or ambushes. | None | True
-| prof_articulation | Joint Articulation | Making flexible items out of hard materials is tricky.  You've done enough of it to understand how to make smoothly articulated joints out of rigid or semi-rigid materials. | None | True
-| prof_closures | Garment Closures | You are familiar with the adjustments and tricks needed to make properly functional buttons, zippers, and other closures on garments. | None | True
-| prof_closures_waterproofing | Fabric Waterproofing | You know how to making garments and fabric containers sealed against water. | None | True
-| prof_elastics | Stretch Fabric | Making elastic bands is easy enough, but making a whole garment from stretchy cloth takes a bit of finesse.  You're good at it. | None | True
-| prof_cobbling | Cobbling | Like a magical elf, you've learned how to construct footwear by hand. | prof_closures / prof_leatherworking_basic | True
-| prof_spinning | Spinning | The art of spinning fiber into thread. | None | True
-| prof_weaving | Weaving | You've learned how to use a loom to produce sheets of fabric from thread. | None | True
-| prof_millinery | Millinery | Like a solitary mouse, you've learned how to construct hats by hand. | prof_leatherworking_basic | True
-| prof_knitting | Knitting | Knitting, one of the oldest ways of tying knots in fiber until it is fabric. | None | True
-| prof_knitting_speed | Speed Knitting | You have knitted and knitted and knitted some more, and have the consistent string tension to show for it.  When you get going, the clicking of your needles is like a metronome. | prof_knitting | True
-| prof_leatherworking_basic | Principles of Leatherworking | You've got a basic familiarity with how to work with leather, furs, hides, and similar materials. | None | True
-| prof_leatherworking | Leatherworking | Working with leather requires a specific set of skills and tools… a set you are familiar with. | prof_leatherworking_basic | True
-| prof_furriery | Furriery | Working with fur and faux fur is a skill all its own. | prof_leatherworking_basic | True
-| prof_chitinworking | Chitinworking | It seems unlikely that anyone prior to the cataclysm knew how to work with the shells of giant bugs as well as you do now. | prof_leatherworking_basic | True
-| prof_chain_armour | Chain Garments | Turning sheets of chain links into effective, wearable clothing that doesn't bind up. | None | True
-| prof_polymerworking | Advanced polymer sewing | You know the tricks for working with Kevlar, Nomex, and other advanced polymer cloth. | None | True
-| prof_knapping | Basic Knapping | You know the basic principles of turning stones into more useful tools. | None | True
-| prof_knapping_speed | Knapping | You've banged rocks together so much and for so long, you've become extremely fast at it. | prof_knapping | True
-| prof_glassblowing | Glassblowing | Working with glass and heat without poisoning or perforating yourself. | None | True
-| prof_plumbing | Plumbing | Working with pipes and pipe fittings to transport fluids without leakage. | None | True
-| prof_pottery | Pottery | Basic pottery, from shaping to working with slip to fuse pieces. | None | True
-| prof_bowyery | Bowyery | The ability to make durable, effective bows. | None | True
-| prof_fletching | Fletching | The skill involved in making arrows that fly true. | None | True
-| prof_basketweaving | Basketweaving | Forming coarse fibers into shapes. | None | True
-| prof_pottery_glazing | Pottery Glazing | Adding glazes to pottery to make them waterproof. | None | True
-| prof_plasticworking | Plastic Working | Working with plastic using your hands, including carving, molding, and gluing it.  You know how to identify thermoplastics that are suitable for mold casting, and how to identify the right plastic for the right job. | None | True
-| prof_carving | Carving | Shaping wood, bone, and similar materials with a cutting implement. | None | True
-| prof_helicopter_pilot | Helicopter Piloting | Before the cataclysm, you were a helicopter pilot.  Now, you just hope you can fly again. | None | False
-| prof_aircraft_mechanic | Airframe and Powerplant Mechanic | You've been trained and certified to repair aircraft.  You're not really sure how that could help you survive now. | None | False
-| prof_gem_setting | Gem Setting | How to add gemstones to jewelry. | prof_fine_metalsmithing / prof_redsmithing | True
-| prof_handloading | Handloading | You know how to accurately measure powder and projectile weights for reloading firearm cartridges. | None | True
-| prof_gunsmithing_basic | Principles of Gunsmithing | A basic understanding of how guns are put together and what tools and materials are needed for the job. | None | True
-| prof_gunsmithing_improv | Improvised Gunmaking | You've become an expert at putting together guns and launchers from makeshift parts. | None | True
-| prof_gunsmithing_antique | Antique Gunsmithing | You're specifically skilled at building and repairing antique guns. | prof_metalworking | True
-| prof_gunsmithing_spring | Spring-powered Guns and Crossbows | Similar to bowyery, the art of making guns that are powered by elastic mechanisms. | None | True
-| prof_gunsmithing_revolver | Revolver Gunsmithing | You've got the know-how to make a classic Western revolver, and its many variants. | prof_gunsmithing_basic | True
+| --- | --- | --- | --- | ---
+| prof_cheesemaking_1 | Principles of Cheesemaking | The basics of curdling and coagulating milk and similar things without the wrong kinds of bacteria and mold winning out. | None | True
+| prof_cheesemaking_2 | Cheesemaking Expert | Taking the basics of curdled milk and making it delicious. | prof_cheesemaking_1 | True
+| --- | --- | --- | --- | ---
+| prof_fermenting | Culinary Fermentation | The basics of fermenting for human consumption, including sanitary technique, avoiding harmful molds, and identifying common problems. | None | True
+| prof_brewing | Brewing | The fine art of brewing grains into beers. | prof_fermenting | True
+| prof_winemaking | Winemaking | The knowledge of how to turn sugary fruits, and occasionally vegetables, into fermented beverages. | prof_fermenting | True
+| prof_lactofermenting | Lactofermentation | The microbiology of most non-alcoholic fermented edibles, from sauerkraut to sourdough. | prof_fermenting | True
+| --- | --- | --- | --- | ---
+| prof_distilling | Distillation | The process of separating two mixed liquids by their different boiling points. | None | True
+| prof_beverage_distilling | Beverage Distillation | Applying the science of distillation to alcoholic beverages to get something tasty. | prof_distilling | True
+| --- | --- | --- | --- | ---
 | prof_intro_chemistry | Principles of Chemistry | You are beginning to grasp a general idea of how elements and compounds react with each other. | None | True
 | prof_intro_biology | Principles of Biology | You are beginning to gain a general idea of how various living beings fuction. | None | True
 | prof_organic_chemistry | Organic Chemistry | Knowledge of the branch of chemistry that studies and uses carbon-containing compounds. | prof_intro_chemistry | True
@@ -73,32 +38,92 @@
 | prof_xenology | Xenology | You are beginning to grasp a general idea of how alien and post-Cataclysm mutated creatures function and operate. | prof_intro_biology | True
 | prof_intro_chem_synth | Principles of Chemical Synthesis | You're beginning to grasp the basics of chemical production. | prof_intro_chemistry | True
 | prof_chem_synth | Complex Chemical Synthesis | The proper understanding of safe chemical synthesization and how to clean your tools used for the next batch. | prof_intro_chem_synth | True
-| prof_distilling | Distillation | The process of separating two mixed liquids by their different boiling points. | None | True
-| prof_metallurgy | Metallurgy | An understanding of the chemistry of metalworking and alloys. | None | True
 | prof_pharmaceutical | Pharmaceutical Production. | An understanding of how to produce various natural and chemical substances pure enough for human consumption. | prof_intro_chemistry / prof_intro_biology | True
+| prof_metallurgy | Metallurgy | An understanding of the chemistry of metalworking and alloys. | None | True
+| --- | --- | --- | --- | ---
 | prof_fibers | Fiber Twisting | You've got a basic grasp of the theory of how to twist and arrange fibers into a more durable cord. | None | True
 | prof_fibers_rope | Ropemaking | Making twisted fibers into durable and useful rope. | prof_fibers | True
+| --- | --- | --- | --- | ---
+| prof_spinning | Spinning | The art of spinning fiber into thread. | None | True
+| prof_weaving | Weaving | You've learned how to use a loom to produce sheets of fabric from thread. | None | True
+| --- | --- | --- | --- | ---
+| prof_knitting | Knitting | Knitting, one of the oldest ways of tying knots in fiber until it is fabric. | None | True
+| prof_knitting_speed | Speed Knitting | You have knitted and knitted and knitted some more, and have the consistent string tension to show for it.  When you get going, the clicking of your needles is like a metronome. | prof_knitting | True
+| --- | --- | --- | --- | ---
+| prof_elastics | Stretch Fabric | Making elastic bands is easy enough, but making a whole garment from stretchy cloth takes a bit of finesse.  You're good at it. | None | True
+| prof_polymerworking | Advanced polymer sewing | You know the tricks for working with Kevlar, Nomex, and other advanced polymer cloth. | None | True
+| prof_basketweaving | Basketweaving | Forming coarse fibers into shapes. | None | True
+| prof_articulation | Joint Articulation | Making flexible items out of hard materials is tricky.  You've done enough of it to understand how to make smoothly articulated joints out of rigid or semi-rigid materials. | None | True
+| prof_chain_armour | Chain Garments | Turning sheets of chain links into effective, wearable clothing that doesn't bind up. | None | True
+| --- | --- | --- | --- | ---
 | prof_tanning_basic | Basic Tanning | You're familiar with the theory behind turning raw hides into leather. | None | True
 | prof_tanning | Tanning | You have a lot of practice and experience with processing hides to leather, as well as various similar techniques like making boiled leather. | None | True
+| --- | --- | --- | --- | ---
+| prof_leatherworking_basic | Principles of Leatherworking | You've got a basic familiarity with how to work with leather, furs, hides, and similar materials. | None | True
+| prof_leatherworking | Leatherworking | Working with leather requires a specific set of skills and tools… a set you are familiar with. | prof_leatherworking_basic | True
+| prof_furriery | Furriery | Working with fur and faux fur is a skill all its own. | prof_leatherworking_basic | True
+| prof_millinery | Millinery | Like a solitary mouse, you've learned how to construct hats by hand. | prof_leatherworking_basic | True
+| prof_chitinworking | Chitinworking | It seems unlikely that anyone prior to the cataclysm knew how to work with the shells of giant bugs as well as you do now. | prof_leatherworking_basic | True
+| prof_closures | Garment Closures | You are familiar with the adjustments and tricks needed to make properly functional buttons, zippers, and other closures on garments. | None | True
+| prof_closures_waterproofing | Fabric Waterproofing | You know how to making garments and fabric containers sealed against water. | None | True
+| prof_cobbling | Cobbling | Like a magical elf, you've learned how to construct footwear by hand. | prof_closures / prof_leatherworking_basic | True
+| --- | --- | --- | --- | ---
+| prof_glassblowing | Glassblowing | Working with glass and heat without poisoning or perforating yourself. | None | True
+| prof_plumbing | Plumbing | Working with pipes and pipe fittings to transport fluids without leakage. | None | True
+| prof_plasticworking | Plastic Working | Working with plastic using your hands, including carving, molding, and gluing it.  You know how to identify thermoplastics that are suitable for mold casting, and how to identify the right plastic for the right job. | None | True
+| prof_carving | Carving | Shaping wood, bone, and similar materials with a cutting implement. | None | True
+| prof_carpentry_basic | Basic Carpentry | Simple projects involving holding planks and panels of wood together with nails or similar fasteners. | None | True
+| --- | --- | --- | --- | ---
+| prof_pottery | Pottery | Basic pottery, from shaping to working with slip to fuse pieces. | None | True
+| prof_pottery_glazing | Pottery Glazing | Adding glazes to pottery to make them waterproof. | None | True
+| --- | --- | --- | --- | ---
+| prof_knapping | Basic Knapping | You know the basic principles of turning stones into more useful tools. | None | True
+| prof_knapping_speed | Knapping | You've banged rocks together so much and for so long, you've become extremely fast at it. | prof_knapping | True
+| --- | --- | --- | --- | ---
+| prof_bowyery | Bowyery | The ability to make durable, effective bows. | None | True
+| prof_fletching | Fletching | The skill involved in making arrows that fly true. | None | True
+| --- | --- | --- | --- | ---
 | prof_bow_basic | Basic Archer's Form | You have grasped some basic understanding on archery, and find handling bows easier. | None | True
 | prof_bow_expert | Expert Archer's Form | After significant practice, you have become an expert in the movements used in drawing and firing a bow, and have strengthened those muscles considerably. | prof_bow_basic | True
 | prof_bow_master | Master Archer's Form | You have drawn and fired a bow so many times, you probably have a bit of a twist in your spine from it.  You've developed what would once have been a world class understanding of the pose and motion of effective archery. | prof_bow_expert | True
+| --- | --- | --- | --- | ---
+| prof_helicopter_pilot | Helicopter Piloting | Before the cataclysm, you were a helicopter pilot.  Now, you just hope you can fly again. | None | False
+| prof_aircraft_mechanic | Airframe and Powerplant Mechanic | You've been trained and certified to repair aircraft.  You're not really sure how that could help you survive now. | None | False
+| --- | --- | --- | --- | ---
 | prof_elec_soldering | Electronics Soldering | An understanding of the skills and tools needed to create durable, effective soldered electrical connections. | None | True
 | prof_electromagnetics | Electromagnetics | A practical working knowledge of electromagnetic fields and their creation and application. | None | True
 | prof_shock_weapons | Electroshock Weapons | An understanding of how to use high voltage, low-current devices to cause debilitating muscle spasms.  Includes some theoretical knowledge of how to protect yourself from these. | None | True
-| prof_carpentry_basic | Basic Carpentry | Simple projects involving holding planks and panels of wood together with nails or similar fasteners. | None | True
+| --- | --- | --- | --- | ---
 | prof_metalworking | Principles of Metalworking | A basic understanding of the properties of metal as a material, and the concepts behind smithing, die casting, and other metalworking techniques. | None | True
 | prof_welding_basic | Principles of Welding | A basic understanding of the different types of welding, welding tools and fuels, how to weld different materials, and more. | prof_metalworking | True
 | prof_welding | Welding | You are an experienced welder. | prof_welding_basic | True
 | prof_blacksmithing | Blacksmithing | The craft of working metal into tools and other items of use. | prof_metalworking | True
 | prof_redsmithing | Redsmithing | Working copper and bronze shares a lot of techniques with blacksmithing, but the more ductile copper-containing metals have a trick all their own. | prof_metalworking | True
 | prof_fine_metalsmithing | Fine Metalsmithing | How to make jewelry from precious metals like gold and silver. | None | True
+| prof_gem_setting | Gem Setting | How to add gemstones to jewelry. | prof_fine_metalsmithing / prof_redsmithing | True
 | prof_armorsmithing | Armorsmithing | How to make articulated armor from pieces of metal. | prof_blacksmithing | True
 | prof_bladesmith | Bladesmithing | How to fabricate sharp and reliable blades from scratch. | prof_blacksmithing | True
 | prof_toolsmithing | Manual Tooling | How to make high-quality tools and parts by hand.  Includes techniques like threading, durable articulation points, and using appropriate metals for appropriate tasks.  Also applies to making blunt instruments that can withstand a severe beating without distortion. | prof_blacksmithing | True
 | prof_wiremaking | Wire Making | How to turn raw ingots and metals into usable wire.  Includes both drawing and extruding. | prof_metalworking | True
+| --- | --- | --- | --- | ---
+| prof_handloading | Handloading | You know how to accurately measure powder and projectile weights for reloading firearm cartridges. | None | True
+| prof_gunsmithing_basic | Principles of Gunsmithing | A basic understanding of how guns are put together and what tools and materials are needed for the job. | None | True
+| prof_gunsmithing_improv | Improvised Gunmaking | You've become an expert at putting together guns and launchers from makeshift parts. | None | True
+| prof_gunsmithing_antique | Antique Gunsmithing | You're specifically skilled at building and repairing antique guns. | prof_metalworking | True
+| prof_gunsmithing_spring | Spring-powered Guns and Crossbows | Similar to bowyery, the art of making guns that are powered by elastic mechanisms. | None | True
+| prof_gunsmithing_revolver | Revolver Gunsmithing | You've got the know-how to make a classic Western revolver, and its many variants. | prof_gunsmithing_basic | True
+| --- | --- | --- | --- | ---
+| prof_lockpicking | Lockpicking | You know how to pick a lock, at least in theory. | None | True
+| prof_lockpicking_expert | Locksmith | You can pick a lock in the dark, blindfolded.  Although that doesn't make it all that much harder.  You're good at locks, OK? | prof_lockpicking | True
+| prof_safecracking | Safecracking | Opening safes is an exacting skill, one that you are proficient at. | None | True
+| --- | --- | --- | --- | ---
+| prof_traps | Principles of Trapping | You know the basics of setting and taking down traps safely. | None | True
+| prof_trapsetting | Trap Setting | You're specifically quite skilled at setting effective traps. | prof_traps | True
+| prof_disarming | Trap Disarming | You know how to take down a trap safely. | prof_traps | True
+| --- | --- | --- | --- | ---
+| prof_spotting | Spotting and Awareness | You are skilled at spotting things out of the ordinary, like traps or ambushes. | None | True
 
-* Note mod proficiencies are not included.
+* Note: Proficiencies from mods are not included.
 This data was extracted using tools/json_tools/table.py
 ```bash
 tools/json_tools/table.py --type=proficiency id name description required_proficiencies can_learn


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Just a plain listing is rather hard to keep track of.

#### Describe the solution

Group into logical categories, partially by proficiency requirements (or logical proficiency requirements; see below).

#### Alternatives

There is probably a better way to format the division between categories. Possibly put in names of categories also?

#### Testing

Preview.

#### Additional context

This has also enabled spotting a few (likely) errors - like prof_pottery_glazing not requiring prof_pottery, prof_closures_waterproofing not requiring prof_closures, prof_tanning not requiring prof_tanning_basic, prof_safecracking not requiring prof_lockpicking, and various gunsmithing proficiencies not requiring prof_gunsmithing_basic.